### PR TITLE
Add option to run chaincodes in dind sidecar

### DIFF
--- a/fabric-kube/backup-flow/values.yaml
+++ b/fabric-kube/backup-flow/values.yaml
@@ -7,32 +7,29 @@ retryCount: 4
 
 backup:
   # if not specified defaults to current date
-  key: 
-  target: 
+  key:
+  target:
     # only azureBlobStorage for now, feel free to implement S3
     type: azureBlobStorage
-    azureBlobStorage: 
+    azureBlobStorage:
       # storage account name
-      accountName: 
+      accountName:
       # container name in storage account
-      destination: hlf-backup 
+      destination: hlf-backup
       # credentials
-      accessKey: 
+      accessKey:
 
 flow:
   peer:
-    backup: 
+    backup:
       # take backup of peers?
       enabled: true
   couchdb:
-    backup: 
+    backup:
       # take backup of CouchDB's?
       enabled: true
   orderer:
     replicas: 1
-    backup: 
+    backup:
       # take backup of orderers?
       enabled: true
-      
-
-

--- a/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
+++ b/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
@@ -286,13 +286,6 @@ spec:
               {{- else }}
                 hlf-peer--{{ $org.Name | lower }}--{{ $peer | lower }}:7051
               {{- end }}
-        {{- if not $.Values.dind.enabled }}
-        - name: CORE_VM_ENDPOINT
-          value: unix:///host/var/run/docker.sock
-        {{- else }}
-        - name: CORE_VM_ENDPOINT
-          value: tcp://localhost:2375
-        {{- end }}
         - name: CORE_PEER_TLS_ENABLED
           value: {{ $.Values.tlsEnabled | quote }}
         - name: FABRIC_LOGGING_SPEC

--- a/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
+++ b/fabric-kube/chaincode-flow/templates/chaincodes-workflow.yaml
@@ -6,7 +6,7 @@
   {{- $_ := set $vars "ordererTlsSecret"  (printf "hlf-orderer--%s-external-tlsca" ($vars.ordererOrgName | lower)) }}
 {{- else }}
   {{- $ordererOrg := index .Values.OrdererOrgs 0 }}
-  {{- $ordererAddress := $.Values.useActualDomains | ternary (printf "%s.%s" (index $ordererOrg.Specs 0).Hostname $ordererOrg.Domain) (printf "hlf-orderer--%s--%s" ($ordererOrg.Name | lower) ((index $ordererOrg.Specs 0).Hostname | lower)) }} 
+  {{- $ordererAddress := $.Values.useActualDomains | ternary (printf "%s.%s" (index $ordererOrg.Specs 0).Hostname $ordererOrg.Domain) (printf "hlf-orderer--%s--%s" ($ordererOrg.Name | lower) ((index $ordererOrg.Specs 0).Hostname | lower)) }}
   {{- $_ := set $vars "ordererOrgName" $ordererOrg.Name }}
   {{- $_ := set $vars "ordererUrl" (printf "%s:7050" $ordererAddress ) }}
   {{- $_ := set $vars "ordererHost" (index $ordererOrg.Specs 0).Hostname }}
@@ -36,7 +36,7 @@ spec:
     hostnames: {{ $alias.hostnames }}
   {{- end }}
   {{- end }}{{""}}
-  
+
   volumes:
   - name: orderer-tlsca
     secret:
@@ -67,12 +67,12 @@ spec:
   - name: peer-{{ $org.Name | lower }}-{{ $peer | lower }}-tls
     secret:
       secretName: hlf-peer--{{ $org.Name | lower }}--{{ $peer | lower }}-tls
-      
+
 {{- end }} {{- /* Peers */ -}}
 {{- end }} {{- /* Orgs */ -}}{{""}}
 
   # chaincodes configMaps
-  {{- range $i, $chaincode := $.Values.network.chaincodes }}    
+  {{- range $i, $chaincode := $.Values.network.chaincodes }}
   {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
   - name: chaincode-{{ $chaincode.name | lower }}
     configMap:
@@ -88,7 +88,7 @@ spec:
 {{- range $i, $chaincode := .Values.network.chaincodes }}
 {{- if or (not $.Values.flow.chaincode.include) (has $chaincode.name $.Values.flow.chaincode.include) }}
 {{- if or $vars.firstStep (not $.Values.flow.chaincode.parallel) }}
-    - 
+    -
 {{- end }}
       - name: chaincode--{{ $chaincode.name }}
         template: chaincode--{{ $chaincode.name }}
@@ -125,7 +125,7 @@ spec:
 {{- $_ := set $vars "firstStep" true }}
   - name: install-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}
     steps:
-     
+
 {{- range $orgName := $chaincode.orgs }}
 {{- range $i, $org := $.Values.PeerOrgs }}
 
@@ -134,13 +134,13 @@ spec:
 {{- range $peerIndex := until ($org.Template.Count | int) }}
 {{- $peer := (printf "peer%s" ($peerIndex | toString)) }}
 {{- if or $vars.firstStep (not $.Values.flow.install.parallel) }}
-    - 
+    -
 {{- end }}
       - name: maybe-install-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
         template: maybe-install-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $org.Name }}--{{ $peer }}
 {{- $_ := set $vars "firstStep" false }}
-{{- end }} {{- /* peerIndex */ -}} 
-{{- end }} {{- /* if org */ -}} 
+{{- end }} {{- /* peerIndex */ -}}
+{{- end }} {{- /* if org */ -}}
 {{- end }} {{- /* peer.Orgs */ -}}
 {{- end }} {{- /* chaincode.orgs */ -}}
 {{- end }} {{- /* if chaincode included */ -}}
@@ -165,13 +165,13 @@ spec:
 
 {{- $peer := "peer0" }}
 {{- if or $vars.firstStep (not $.Values.flow.instantiate.parallel) }}
-    - 
+    -
 {{- end }}
       - name: maybe-instantiate-or-upgrade-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
         template: maybe-instantiate-or-upgrade-chaincode--{{ $chaincode.name }}-{{ $version | replace "." "-" }}--{{ $channel.name  }}--{{ $org.Name }}--{{ $peer }}
 
 {{- $_ := set $vars "firstStep" false }}
-{{- end }} {{- /* if org */ -}} 
+{{- end }} {{- /* if org */ -}}
 {{- end }} {{- /* peer.Orgs */ -}}
 {{- end }} {{- /* chaincode.channels */ -}}
 {{- end }} {{- /* if chaincode included */ -}}
@@ -196,14 +196,14 @@ spec:
 {{- $peer := (printf "peer%s" ($peerIndex | toString)) }}
 
 {{- if or $vars.firstStep (not $.Values.flow.invoke.parallel) }}
-    - 
+    -
 {{- end }}
       - name: invoke-chaincode--{{ $chaincode.name }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
         template: invoke-chaincode--{{ $chaincode.name }}--{{ $channel.name }}--{{ $org.Name }}--{{ $peer }}
 
 {{- $_ := set $vars "firstStep" false }}
-{{- end }} {{- /* peerIndex */ -}} 
-{{- end }} {{- /* if org */ -}} 
+{{- end }} {{- /* peerIndex */ -}}
+{{- end }} {{- /* if org */ -}}
 {{- end }} {{- /* peer.Orgs */ -}}
 {{ end }} {{- /* channel.orgs */ -}}
 {{- end }} {{- /* chaincode.channels */ -}}
@@ -238,33 +238,33 @@ spec:
       image: raft/hl-fabric-tools:1.4.3
       command: [sh]
       source: |
-          if peer chaincode checkinstalled --name {{ $chaincode.name }} --version {{ $version }}; then  
-            echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is already installed to peer {{ $peer }}, exiting with 0' 
-            exit 0 
-          else 
-            result=$? 
-            echo "-- result is: $result" 
-            if test $result -ne 99; then 
-              echo "-- result is not 99, exiting with $result" 
-              exit $result 
-            fi 
-          fi 
+          if peer chaincode checkinstalled --name {{ $chaincode.name }} --version {{ $version }}; then
+            echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is already installed to peer {{ $peer }}, exiting with 0'
+            exit 0
+          else
+            result=$?
+            echo "-- result is: $result"
+            if test $result -ne 99; then
+              echo "-- result is not 99, exiting with $result"
+              exit $result
+            fi
+          fi
 
-          echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is not installed to peer {{ $peer }}, will install..' 
+          echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is not installed to peer {{ $peer }}, will install..'
 
           {{- if eq $language "golang" }}
 
-          # chaincode is packed with tar, first extract it 
-          mkdir -p $GOPATH/src/chaincode && 
-          tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C $GOPATH/src/chaincode && 
+          # chaincode is packed with tar, first extract it
+          mkdir -p $GOPATH/src/chaincode &&
+          tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C $GOPATH/src/chaincode &&
           peer chaincode install --path chaincode/{{ $chaincode.name }} --name {{ $chaincode.name }} \
               --version {{ $version }} --lang {{ $language }}
 
           {{- else }}
 
-          # chaincode is packed with tar, first extract it 
-          mkdir -p /chaincode && 
-          tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C /chaincode && 
+          # chaincode is packed with tar, first extract it
+          mkdir -p /chaincode &&
+          tar -xf /hlf_config/chaincode/{{ $chaincode.name }}.tar -C /chaincode &&
           peer chaincode install --path /chaincode/{{ $chaincode.name }} --name {{ $chaincode.name }} \
               --version {{ $version }} --lang {{ $language }}
 
@@ -277,15 +277,22 @@ spec:
           name: peer-{{ $org.Name | lower }}-admin-msp
         - mountPath: /hlf_config/chaincode/
           name: chaincode-{{ $chaincode.name | lower }}
-      
+
       env:
         - name: CORE_PEER_ADDRESS
-          value: |- 
+          value: |-
               {{- if $.Values.useActualDomains }}
                 {{ $peer }}.{{ $org.Domain }}:7051
               {{- else }}
                 hlf-peer--{{ $org.Name | lower }}--{{ $peer | lower }}:7051
               {{- end }}
+        {{- if not $.Values.dind.enabled }}
+        - name: CORE_VM_ENDPOINT
+          value: unix:///host/var/run/docker.sock
+        {{- else }}
+        - name: CORE_VM_ENDPOINT
+          value: tcp://localhost:2375
+        {{- end }}
         - name: CORE_PEER_TLS_ENABLED
           value: {{ $.Values.tlsEnabled | quote }}
         - name: FABRIC_LOGGING_SPEC
@@ -299,8 +306,8 @@ spec:
         - name: CORE_PEER_TLS_ROOTCERT_FILE
           value: /etc/hyperledger/fabric/tls/ca.crt
 
-{{ end }} {{- /* peerIndex */ -}} 
-{{ end }} {{- /* if org */ -}} 
+{{ end }} {{- /* peerIndex */ -}}
+{{ end }} {{- /* if org */ -}}
 {{ end }} {{- /* peer.Orgs */ -}}
 {{ end }} {{- /* chaincode.orgs */ -}}
 {{- end }} {{- /* if chaincode included */ -}}
@@ -335,41 +342,41 @@ spec:
       image: raft/hl-fabric-tools:1.4.3
       command: [sh]
       source: |
-          if peer chaincode checkinstantiated --name {{ $chaincode.name }} --version {{ $version }} --channelID {{ $channel.name }}; then  
-            echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is already instantiated on channel {{ $channel.name }}, exiting with 0' 
-            exit 0 
-          else 
-            result=$? 
-            echo "-- result is: $result" 
-            if test $result -ne 99; then 
-              echo "-- result is not 99, exiting with $result" 
-              exit $result 
-            fi 
-          fi 
+          if peer chaincode checkinstantiated --name {{ $chaincode.name }} --version {{ $version }} --channelID {{ $channel.name }}; then
+            echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is already instantiated on channel {{ $channel.name }}, exiting with 0'
+            exit 0
+          else
+            result=$?
+            echo "-- result is: $result"
+            if test $result -ne 99; then
+              echo "-- result is not 99, exiting with $result"
+              exit $result
+            fi
+          fi
 
-          echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is not instantiated on channel {{ $channel.name }}, will check another version..' 
+          echo '-- Chaincode {{ $chaincode.name }} version {{ $version }} is not instantiated on channel {{ $channel.name }}, will check another version..'
 
-          if peer chaincode checkinstantiated --name {{ $chaincode.name }} --channelID {{ $channel.name }}; then  
-            echo '-- Chaincode {{ $chaincode.name }} with another version is already instantiated on channel {{ $channel.name }}, will perform an upgrade chaincode transaction..' 
-            doUpgrade=true 
-          else 
-            result=$? 
-            echo "-- result is: $result" 
-            if test $result -ne 99; then 
-              echo "-- result is not 99, exiting with $result" 
-              exit $result 
-            fi 
-          fi 
+          if peer chaincode checkinstantiated --name {{ $chaincode.name }} --channelID {{ $channel.name }}; then
+            echo '-- Chaincode {{ $chaincode.name }} with another version is already instantiated on channel {{ $channel.name }}, will perform an upgrade chaincode transaction..'
+            doUpgrade=true
+          else
+            result=$?
+            echo "-- result is: $result"
+            if test $result -ne 99; then
+              echo "-- result is not 99, exiting with $result"
+              exit $result
+            fi
+          fi
 
-          if [ -z "$doUpgrade" ]; then 
-            echo '-- Chaincode {{ $chaincode.name }} is not instantiated on channel {{ $channel.name }}, will instantiate..' 
+          if [ -z "$doUpgrade" ]; then
+            echo '-- Chaincode {{ $chaincode.name }} is not instantiated on channel {{ $channel.name }}, will instantiate..'
             peer chaincode instantiate --name {{ $chaincode.name }} --version {{ $version }} --lang {{ $language }} \
                   --channelID {{ $channel.name }} --orderer {{ $vars.ordererUrl }} \
                   --policy "{{ $channel.policy }}" --ctor '{"Args":[""]}' \
             {{- if $.Values.tlsEnabled }}
                   --tls --cafile /hlf_config/orderer-tlsca/tlscacert.pem \
             {{- end }}
-          ; else 
+          ; else
             peer chaincode upgrade --name {{ $chaincode.name }} --version {{ $version }} --lang {{ $language }} \
                   --channelID {{ $channel.name }} --orderer {{ $vars.ordererUrl }} \
                   --policy "{{ $channel.policy }}" --ctor '{"Args":[""]}' \
@@ -385,10 +392,10 @@ spec:
           name: peer-{{ $org.Name | lower }}-{{ $peer | lower }}-tls
         - mountPath: /etc/hyperledger/fabric/msp/
           name: peer-{{ $org.Name | lower }}-admin-msp
-      
+
       env:
         - name: CORE_PEER_ADDRESS
-          value: |- 
+          value: |-
               {{- if $.Values.useActualDomains }}
                 {{ $peer }}.{{ $org.Domain }}:7051
               {{- else }}
@@ -407,7 +414,7 @@ spec:
         - name: CORE_PEER_TLS_ROOTCERT_FILE
           value: /etc/hyperledger/fabric/tls/ca.crt
 
-{{ end }} {{- /* if org */ -}} 
+{{ end }} {{- /* if org */ -}}
 {{ end }} {{- /* peer.Orgs */ -}}
 {{ end }} {{- /* chaincode.channels */ -}}
 {{- end }} {{- /* if chaincode included */ -}}
@@ -452,10 +459,10 @@ spec:
           name: peer-{{ $org.Name | lower }}-{{ $peer | lower }}-tls
         - mountPath: /etc/hyperledger/fabric/msp/
           name: peer-{{ $org.Name | lower }}-admin-msp
-      
+
       env:
         - name: CORE_PEER_ADDRESS
-          value: |- 
+          value: |-
               {{- if $.Values.useActualDomains }}
                 {{ $peer }}.{{ $org.Domain }}:7051
               {{- else }}
@@ -474,8 +481,8 @@ spec:
         - name: CORE_PEER_TLS_ROOTCERT_FILE
           value: /etc/hyperledger/fabric/tls/ca.crt
 
-{{ end }} {{- /* peerIndex */ -}} 
-{{ end }} {{- /* if org */ -}} 
+{{ end }} {{- /* peerIndex */ -}}
+{{ end }} {{- /* if org */ -}}
 {{ end }} {{- /* peer.Orgs */ -}}
 {{ end }} {{- /* channel.orgs */ -}}
 {{ end }} {{- /* chaincode.channels */ -}}

--- a/fabric-kube/chaincode-flow/values.yaml
+++ b/fabric-kube/chaincode-flow/values.yaml
@@ -31,6 +31,11 @@ externalOrderer:
 
 logLevel: info
 
+# Docker-in-docker settings
+dind:
+  # if set to true peers will use a docker in docker container for their chaincodes
+  enabled: true
+
 flow:
   chaincode:
     # should we run top level chaincode flows in parallel?
@@ -39,16 +44,16 @@ flow:
     include: []
   install:
     # should we run install step?
-    enabled: true  
+    enabled: true
     parallel: true
   instantiate:
     # should we run instantiate/upgrade step?
-    enabled: true  
+    enabled: true
     parallel: true
   invoke:
-    # should we run invoke step? 
+    # should we run invoke step?
     # we invoke chaincode after instantiate/upgrade to force the peers to actually create the chaincode containers
-    enabled: true 
+    enabled: true
     parallel: true
     function: '{"function":"ping","Args":[""]}'
 

--- a/fabric-kube/chaincode-flow/values.yaml
+++ b/fabric-kube/chaincode-flow/values.yaml
@@ -31,11 +31,6 @@ externalOrderer:
 
 logLevel: info
 
-# Docker-in-docker settings
-dind:
-  # if set to true peers will use a docker in docker container for their chaincodes
-  enabled: true
-
 flow:
   chaincode:
     # should we run top level chaincode flows in parallel?

--- a/fabric-kube/channel-flow/templates/channel-workflow.yaml
+++ b/fabric-kube/channel-flow/templates/channel-workflow.yaml
@@ -265,13 +265,6 @@ spec:
       env:
         - name: FABRIC_LOGGING_SPEC
           value: {{ $.Values.logLevel }}
-        {{- if not $.Values.dind.enabled }}
-        - name: CORE_VM_ENDPOINT
-          value: unix:///host/var/run/docker.sock
-        {{- else }}
-        - name: CORE_VM_ENDPOINT
-          value: tcp://localhost:2375
-        {{- end }}
         - name: CORE_PEER_LOCALMSPID
           value: {{ $org.Name }}MSP
         - name: CORE_PEER_TLS_CERT_FILE

--- a/fabric-kube/channel-flow/templates/channel-workflow.yaml
+++ b/fabric-kube/channel-flow/templates/channel-workflow.yaml
@@ -265,6 +265,13 @@ spec:
       env:
         - name: FABRIC_LOGGING_SPEC
           value: {{ $.Values.logLevel }}
+        {{- if not $.Values.dind.enabled }}
+        - name: CORE_VM_ENDPOINT
+          value: unix:///host/var/run/docker.sock
+        {{- else }}
+        - name: CORE_VM_ENDPOINT
+          value: tcp://localhost:2375
+        {{- end }}
         - name: CORE_PEER_LOCALMSPID
           value: {{ $org.Name }}MSP
         - name: CORE_PEER_TLS_CERT_FILE
@@ -340,6 +347,13 @@ spec:
               {{- else }}
                 hlf-peer--{{ $org.Name | lower }}--{{ $peer | lower }}:7051
               {{- end }}
+        {{- if not $.Values.dind.enabled }}
+        - name: CORE_VM_ENDPOINT
+          value: unix:///host/var/run/docker.sock
+        {{- else }}
+        - name: CORE_VM_ENDPOINT
+          value: tcp://localhost:2375
+        {{- end }}
         - name: CORE_PEER_TLS_ENABLED
           value: {{ $.Values.tlsEnabled | quote }}
         - name: FABRIC_LOGGING_SPEC

--- a/fabric-kube/channel-flow/templates/channel-workflow.yaml
+++ b/fabric-kube/channel-flow/templates/channel-workflow.yaml
@@ -340,13 +340,6 @@ spec:
               {{- else }}
                 hlf-peer--{{ $org.Name | lower }}--{{ $peer | lower }}:7051
               {{- end }}
-        {{- if not $.Values.dind.enabled }}
-        - name: CORE_VM_ENDPOINT
-          value: unix:///host/var/run/docker.sock
-        {{- else }}
-        - name: CORE_VM_ENDPOINT
-          value: tcp://localhost:2375
-        {{- end }}
         - name: CORE_PEER_TLS_ENABLED
           value: {{ $.Values.tlsEnabled | quote }}
         - name: FABRIC_LOGGING_SPEC

--- a/fabric-kube/channel-flow/values.yaml
+++ b/fabric-kube/channel-flow/values.yaml
@@ -31,6 +31,11 @@ externalOrderer:
 
 logLevel: info
 
+# Docker-in-docker settings
+dind:
+  # if set to true peers will use a docker in docker container for their chaincodes
+  enabled: true
+
 flow:
   channel:
     # should we run top level channel flows in parallel? 
@@ -38,10 +43,10 @@ flow:
     parallel: false
     # fill in this array with channel names to limit the channel flow only to these ones
     include: []
-  join: 
-    # run channel join flows in parallel? 
+  join:
+    # run channel join flows in parallel?
     parallel: true
-  update: 
-    # run channel update flows in parallel? 
+  update:
+    # run channel update flows in parallel?
     parallel: true
 

--- a/fabric-kube/channel-flow/values.yaml
+++ b/fabric-kube/channel-flow/values.yaml
@@ -31,11 +31,6 @@ externalOrderer:
 
 logLevel: info
 
-# Docker-in-docker settings
-dind:
-  # if set to true peers will use a docker in docker container for their chaincodes
-  enabled: true
-
 flow:
   channel:
     # should we run top level channel flows in parallel? 

--- a/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
@@ -325,6 +325,8 @@ spec:
         - name: CORE_PEER_TLS_ROOTCERT_FILE
           value: /etc/hyperledger/fabric/tls/ca.crt
         
+        - name: CORE_CHAINCODE_BUILDER
+          value: hyperledger/fabric-ccenv:{{ $.Values.hyperledgerVersion }}
         - name: CORE_CHAINCODE_LOGGING_LEVEL
           value: {{ $.Values.peer.chaincode.logging.level }}
         - name: CORE_CHAINCODE_LOGGING_SHIM
@@ -393,7 +395,11 @@ spec:
         env:
         - name: DOCKER_TLS_CERTDIR
           # leave empty to disable TLS
-          value: 
+          value:
+        {{- if $.Values.peer.docker.registryMirror.enabled }}
+        - name: DOCKER_OPTS
+          value: --registry-mirror={{ $.Values.peer.docker.registryMirror.address }}
+        {{- end }}
 
       {{- end }} {{- /* if peer.docker.dind.enabled */ -}}{{""}}
 

--- a/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
@@ -385,6 +385,9 @@ spec:
       # Docker dind container
       - name: docker
         image: {{ $.Values.peer.docker.dind.image }}
+        {{- if $.Values.peer.docker.registryMirror.enabled }}
+        args: ["--registry-mirror={{ $.Values.peer.docker.registryMirror.address }}"]
+        {{- end }}
         securityContext:
           privileged: true
       
@@ -396,10 +399,6 @@ spec:
         - name: DOCKER_TLS_CERTDIR
           # leave empty to disable TLS
           value:
-        {{- if $.Values.peer.docker.registryMirror.enabled }}
-        - name: DOCKER_OPTS
-          value: --registry-mirror={{ $.Values.peer.docker.registryMirror.address }}
-        {{- end }}
 
       {{- end }} {{- /* if peer.docker.dind.enabled */ -}}{{""}}
 

--- a/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
+++ b/fabric-kube/hlf-kube/templates/peer-statefulset.yaml
@@ -288,7 +288,7 @@ spec:
         - name: CORE_PEER_CHAINCODELISTENADDRESS
           value: 0.0.0.0:7052
         - name: CORE_PEER_GOSSIP_BOOTSTRAP
-          value: >- 
+          value: >-
         {{- range $peerIndexInner := until ($org.Template.Count | int) }}
         {{- $peer := (printf "peer%s" ($peerIndexInner | toString)) }}
         {{- $peerGossipAddress := $.Values.useActualDomains | ternary (printf "%s.%s:7051" $peer $org.Domain) (printf "hlf-peer--%s--%s:7051" ($org.Name | lower) ($peer | lower)) }}

--- a/fabric-kube/hlf-kube/values.yaml
+++ b/fabric-kube/hlf-kube/values.yaml
@@ -53,7 +53,7 @@ peer:
   docker:
     dind:
       # use a side car docker in docker container?
-      enabled: true
+      enabled: false
       # dind docker image
       image: docker:19.03.12-dind
       persistence:
@@ -61,7 +61,7 @@ peer:
         size: 16Gi
     registryMirror:
       # use a registry mirror for docker?
-      enabled: true
+      enabled: false
       address: http://192.168.206.128:5000
   ingress:
     enabled: false

--- a/fabric-kube/hlf-kube/values.yaml
+++ b/fabric-kube/hlf-kube/values.yaml
@@ -51,7 +51,7 @@ peer:
     enabled: false
     size: 16Gi
   docker:
-    dind: 
+    dind:
       # use a side car docker in docker container?
       enabled: true
       # dind docker image
@@ -59,6 +59,10 @@ peer:
       persistence:
         enabled: false
         size: 16Gi
+    registryMirror:
+      # use a registry mirror for docker?
+      enabled: false
+      address: http://192.168.206.128:5000
   ingress:
     enabled: false
     annotations:

--- a/fabric-kube/hlf-kube/values.yaml
+++ b/fabric-kube/hlf-kube/values.yaml
@@ -53,9 +53,9 @@ peer:
   docker:
     dind: 
       # use a side car docker in docker container?
-      enabled: false
+      enabled: true
       # dind docker image
-      image: docker:19.03.8-dind
+      image: docker:19.03.12-dind
       persistence:
         enabled: false
         size: 16Gi
@@ -106,7 +106,6 @@ couchdb:
   restore: 
     # restore CouchDB's data from backup during restore procedure?
     enabled: true
-
 
 # Orderer settings. applies to all Orderer pods
 orderer:

--- a/fabric-kube/hlf-kube/values.yaml
+++ b/fabric-kube/hlf-kube/values.yaml
@@ -61,7 +61,7 @@ peer:
         size: 16Gi
     registryMirror:
       # use a registry mirror for docker?
-      enabled: false
+      enabled: true
       address: http://192.168.206.128:5000
   ingress:
     enabled: false


### PR DESCRIPTION
This is an extension to the work started by @raftAtGit:

I'm trying to get the examples to work with a single node cluster set up with kind. Here are the changes I made:

- [x] To make channel creation and chaincode installation / instantiation work with dind sidecars the workflows need to be extended to use the tcp endpoint over the socket as well.
- [ ] Update README.md to reflect changes and inform users about the option to use dind sidecars.
- [ ] When installing argo the default resource config needs to be adapted to use Kubernetes API (k8sapi) instead of the default docker executor. Otherwise argo workflows break by accessing the docker socket of the node. (Probably just add to README.md)
- [ ] A role binding for default-admin to admin needs to be created to make the k8sapi executor work (Probably just update README.md)
- [x] When installing chaincode for some reason the peer complains it cannot pull ``hyperledger/fabric-ccenv:latest`` from the docker hub. If I sh into the docker sidecar and manually pull the image the chaincode workflow passes. I will extend the workflow to do that automatically. Additionally this should pull the version defined by the default values of hlf-kube and tag it as latest to ensure that the same hlf version is used everywhere.

I noticed that a custom build of the ``hyperledger/fabric-tools`` image is used in some places and comes in 2 different flavors (normal and extended). I couldn't find any source for ``raft/hl-fabric-tools``. To my understanding they contain a fork of the 1.4.3 version of the tools with some extensions to the peer command? At least I found this PR: https://github.com/hyperledger/fabric/pull/345

This seems to be quite a lot of effort to maintain and in the PR it is even mentioned that it won't be ported to 1.4.7 or 2.x. I would like to try and refactor the relevant scripts to work with the official ``fabric-tools`` image to reduce the effort of maintenance. Do the images contain any additional changes to the official ones beside the patch for the new commands? Why is there an extended image?